### PR TITLE
Changed an interface of AuthService.check_permission method

### DIFF
--- a/dpl/auth/abs_auth_service.py
+++ b/dpl/auth/abs_auth_service.py
@@ -6,6 +6,8 @@ is not a child of AbsEntityService and was mainly created as
 a facade for two other services - SessionService and UserService
 """
 
+from typing import Sequence, Mapping
+from dpl.utils.empty_mapping import EMPTY_MAPPING
 from dpl.dtos.session_dto import SessionDto
 
 
@@ -78,7 +80,7 @@ class AbsAuthService(object):
     def check_permission(
             self, access_token: str,
             in_domain: str, to_execute: str,
-            *args, **kwargs
+            args: Sequence = (), kwargs: Mapping = EMPTY_MAPPING
     ) -> None:
         """
         Checks if the the specified access token allows to execute

--- a/dpl/auth/auth_service.py
+++ b/dpl/auth/auth_service.py
@@ -1,3 +1,6 @@
+from typing import Sequence, Mapping
+from dpl.utils.empty_mapping import EMPTY_MAPPING
+
 from dpl.dtos.session_dto import SessionDto
 from dpl.services.service_exceptions import ServiceEntityResolutionError
 from dpl.services.abs_user_service import AbsUserService
@@ -102,7 +105,7 @@ class AuthService(AbsAuthService):
     def check_permission(
             self, access_token: str,
             in_domain: str, to_execute: str,
-            *args, **kwargs
+            args: Sequence = (), kwargs: Mapping = EMPTY_MAPPING
     ) -> None:
         """
         Checks if the the specified access token allows to execute


### PR DESCRIPTION
A detailed information about what was changed in the interface is available in c3f9715.

In short: All optional arguments (i.e. arguments which was passed on the method call to be checked) are now specified in `args` and `kwargs` parameters, not directly in line after primary (`access_token`, `in_domain` and `to_execute`) arguments 