### PR TITLE
New REST API provider

### DIFF
--- a/dpl/api/__init__.py
+++ b/dpl/api/__init__.py
@@ -1,5 +1,5 @@
 from .api_gateway import ApiGateway
-from .rest_api import RestApi
+from .rest_api_legacy import RestApiLegacy
 from . import exceptions
 
-__all__ = ["ApiGateway", "RestApi"]
+__all__ = ["ApiGateway", "RestApiLegacy"]

--- a/dpl/api/rest_api/__init__.py
+++ b/dpl/api/rest_api/__init__.py
@@ -1,0 +1,4 @@
+"""
+This package contains subapps that implement a REST-like
+API for accessing functionality of an everpl instance
+"""

--- a/dpl/api/rest_api/common.py
+++ b/dpl/api/rest_api/common.py
@@ -1,0 +1,55 @@
+"""
+This module contains some utility methods and definitions
+which are commonly used by request handlers
+"""
+import json
+import warnings
+
+from typing import Callable, Awaitable
+
+import aiohttp.web as web
+
+from dpl.utils.json_enum_encoder import JsonEnumEncoder
+
+
+# Declare an alias for request handler type
+RequestHandlerType = Callable[[web.Request], Awaitable[web.Response]]
+
+# Declare constants:
+CONTENT_TYPE_JSON = "application/json"
+
+
+def make_error_response(message: str, status: int = 400) -> web.Response:
+    """
+    Creates a simple JSON response with specified error code and explanatory message
+    :param message: explanatory message
+    :param status: status code of the response
+    :return: created response
+    """
+    warnings.warn(DeprecationWarning)
+
+    return make_json_response(
+        content={"status": status, "message": message},
+        status=status
+    )
+
+
+def make_json_response(content: dict, status: int = 200) -> web.Response:
+    """
+    Serialize given content to JSON and create a corresponding response.
+
+    web.json_response() method was not used because it doesn't support usage of
+    custom JSON encoders by default (functools.partial() may be used to create a
+    corresponding callable which must to be passed into 'json_response' function
+    as 'dumps' keyword argument).
+
+    :param content: content to serialize
+    :param status: status code of the response
+    :return: created response
+    """
+    serialized = json.dumps(obj=content, cls=JsonEnumEncoder)
+    response = web.Response(status=status)
+    response.content_type = CONTENT_TYPE_JSON
+    response.body = serialized
+
+    return response

--- a/dpl/api/rest_api/json_decode_decorator.py
+++ b/dpl/api/rest_api/json_decode_decorator.py
@@ -1,0 +1,43 @@
+import json
+import functools
+from typing import Callable, Awaitable
+
+import aiohttp.web as web
+
+from dpl.api.api_errors import ERROR_TEMPLATES
+from .common import CONTENT_TYPE_JSON, make_json_response
+
+
+RequestHandlerType = Callable[[web.Request], Awaitable[web.Response]]
+
+
+def json_decode_decorator(decorated: RequestHandlerType) -> RequestHandlerType:
+    """
+    This decorator allows to decorate web requests handlers
+    for Content-Type HTTP header checking and processing of
+    JSON decoding errors
+
+    :param decorated: a web request handler to be decorated
+    :return: a wrapper function which implements a request
+             checking logic
+    """
+    @functools.wraps(decorated)
+    async def _wrapper(request: web.Request) -> web.Response:
+        if request.content_type != CONTENT_TYPE_JSON:
+            return make_json_response(
+                status=400,
+                content=ERROR_TEMPLATES[1000].to_dict()
+            )
+
+        try:
+            result = await decorated(request)
+        except json.JSONDecodeError:
+            return make_json_response(
+                status=400,
+                content=ERROR_TEMPLATES[1001].to_dict()
+            )
+
+        return result
+
+    return _wrapper
+

--- a/dpl/api/rest_api/messages_subapp.py
+++ b/dpl/api/rest_api/messages_subapp.py
@@ -1,0 +1,181 @@
+import warnings
+from typing import Mapping
+
+import aiohttp.web as web
+from dpl.utils.empty_mapping import EMPTY_MAPPING
+
+from dpl.services.abs_thing_service import (
+    AbsThingService,
+    ServiceTypeError,
+    ServiceEntityResolutionError
+)
+from dpl.auth.exceptions import AuthInsufficientPrivilegesError
+
+from .json_decode_decorator import json_decode_decorator
+from .restricted_access_decorator import restricted_access
+from .common import (
+    make_json_response
+)
+
+
+def make_error_response(message: str, status: int = 400) -> web.Response:
+    """
+    Creates a simple JSON response with specified error code and explanatory message
+    :param message: explanatory message
+    :param status: status code of the response
+    :return: created response
+    """
+    return make_json_response(
+        content={"status": status, "message": message},
+        status=status
+    )
+
+
+def build_messages_subapp(
+        thing_service: AbsThingService,
+        additional_data: Mapping = EMPTY_MAPPING
+) -> web.Application:
+    """
+    A factory of aiohttp's Applications. Initializes and returns
+    an Application for sending of commands to Actuators
+
+    :param thing_service: an instance of thing_service used
+          for managing of Things
+    :param additional_data: additional data to be saved in app's
+           context (data store)
+    :return: an instance of aiohttp Application
+    """
+    warnings.warn(
+        "The /messages/ route will be removed in v0.3",
+        PendingDeprecationWarning
+    )
+
+    app = web.Application()
+    app['thing_service'] = thing_service
+    app.update(additional_data)
+    router = app.router
+
+    router.add_post(path='/', handler=messages_post_handler)
+    router.add_route(method='OPTIONS', path='/', handler=messages_options_handler)
+
+    return app
+
+
+@restricted_access
+@json_decode_decorator
+async def messages_post_handler(request: web.Request) -> web.Response:
+    """
+    ONLY FOR COMPATIBILITY: Accept 'action requested' messages from clients.
+    Handle POST requests for /messages/ path.
+
+    :param request: request to be processed
+    :return: a response to request
+    """
+    warnings.warn(PendingDeprecationWarning)
+
+    request_body = await request.json()
+
+    msg_type = request_body.get("type", None)
+
+    if msg_type is None:
+        return make_error_response(status=400, message="Invalid message format: missing 'type' value")
+
+    if msg_type != "user_request":
+        return make_error_response(
+            status=400,
+            message="Unsupported message type: {0}. "
+                    "Only type='user_request' is supported".format(msg_type)
+        )
+
+    msg_event = request_body.get("event", None)
+
+    if msg_event != "action_requested":
+        return make_error_response(
+            status=400,
+            message="Unsupported event specified: {0}. "
+                    "Only event='action_requested' is supported".format(msg_event)
+        )
+
+    msg_body = request_body.get("body", None)  # type: dict
+
+    if not isinstance(msg_body, dict):
+        return make_error_response(
+            status=400,
+            message="Message body is invalid or absent."
+        )
+
+    # TODO: Consider consolidation of error messages and adding of link to knowledge base
+
+    thing_action = msg_body.get("action", None)  # type: str
+
+    if thing_action is None:
+        return make_error_response(
+            status=400,
+            message="Requested action is not specified in message body or is null."
+        )
+
+    thing_id = msg_body.get("obj_id", None)  # type: str
+
+    if thing_id is None:
+        return make_error_response(
+            status=400,
+            message="obj_id (unique identifier of specific Thing)"
+                    "is not specified or is null."
+        )
+
+    thing_action_params = msg_body.get("action_params", None)  # type: dict
+
+    if not isinstance(thing_action_params, dict):
+        return make_error_response(
+            status=400,
+            message="A value of action_params is invalid or absent."
+                    "It must be a dictionary that contains all parameters"
+                    "that need to be passed to thing to perform the specified action."
+        )
+
+    thing_service = request.app['thing_service']
+
+    try:
+        thing_service.send_command(
+            to_actuator_id=thing_id,
+            command=thing_action,
+            command_args=thing_action_params
+        )
+    except AuthInsufficientPrivilegesError:
+        return make_error_response(
+            status=403,
+            message="You are not authorized to process this action"
+        )
+
+    except ServiceEntityResolutionError:
+        return make_error_response(
+            status=400,
+            message="Requested Thing is not existing"
+        )
+
+    except ServiceTypeError:
+        return make_error_response(
+            status=400,
+            message="Requested to send a command to a non-actuator Thing"
+        )
+
+    return make_json_response(
+        content={"message": "accepted"},
+        status=202
+    )
+
+
+async def messages_options_handler(request: web.Request) -> web.Response:
+    """
+    A handler for OPTIONS request for path /messages/.
+
+    Returns a response that contains 'Allow' header with all allowed HTTP methods.
+
+    :param request: request to be handled
+    :return: a response to request
+    """
+    return web.Response(
+        body=None,
+        status=204,
+        headers={'Allow': 'POST, HEAD, OPTIONS'}
+    )

--- a/dpl/api/rest_api/placements_subapp.py
+++ b/dpl/api/rest_api/placements_subapp.py
@@ -1,0 +1,138 @@
+"""
+This module contains definitions of an aiohttp
+application controlling the /placements/ route
+"""
+from typing import Mapping
+
+import aiohttp.web as web
+from dpl.utils.empty_mapping import EMPTY_MAPPING
+
+from dpl.services.abs_placement_service import (
+    AbsPlacementService,
+    ServiceEntityResolutionError
+)
+from dpl.auth.exceptions import AuthInsufficientPrivilegesError
+from dpl.api.api_errors import ERROR_TEMPLATES
+from .common import make_json_response
+from .restricted_access_decorator import restricted_access
+
+
+def build_placements_subapp(
+        placement_service: AbsPlacementService,
+        additional_data: Mapping = EMPTY_MAPPING
+) -> web.Application:
+    """
+    A factory of aiohttp's Applications. Initializes and returns
+    an Application for managing of Placements
+
+    :param placement_service: an instance of thing_service used
+           for managing of Placements
+    :param additional_data: additional data to be saved in app's
+           context (data store)
+    :return: an instance of aiohttp Application
+    """
+    app = web.Application()
+    app['placement_service'] = placement_service
+    app.update(additional_data)
+    router = app.router
+
+    router.add_get(path='/', handler=placements_get_handler)
+    router.add_route(method='OPTIONS', path='/', handler=placements_options_handler)
+    router.add_get(path='/{id}', handler=placement_get_handler)
+    router.add_route(method='OPTIONS', path='/{id}', handler=placement_options_handler)
+
+    return app
+
+
+@restricted_access
+async def placements_get_handler(request: web.Request) -> web.Response:
+    """
+    A handler for GET requests for path /placements/
+
+    :param request: request to be processed
+    :return: a response to request
+    """
+    placement_service = request.app['placement_service']  # type: AbsPlacementService
+
+    try:
+        return make_json_response(
+            {"placements": placement_service.view_all()}
+        )
+    except AuthInsufficientPrivilegesError:
+        error_dict = ERROR_TEMPLATES[2110].to_dict()
+
+        error_dict["user_message"] = error_dict["user_message"].format(action="viewing of placements data")
+
+        return make_json_response(
+            status=403,
+            content=error_dict
+        )
+
+
+async def placements_options_handler(request: web.Request) -> web.Response:
+    """
+    A handler for OPTIONS request for path /placements/.
+
+    Returns a response that contains 'Allow' header with all allowed HTTP methods.
+
+    :param request: request to be handled
+    :return: a response to request
+    """
+    return web.Response(
+        body=None,
+        status=204,
+        headers={'Allow': 'GET, HEAD, OPTIONS'}
+    )
+
+
+def _get_placement_id(request: web.Request) -> str:
+    placement_id = request.match_info['id']
+
+    return placement_id
+
+
+@restricted_access
+async def placement_get_handler(request: web.Request) -> web.Response:
+    """
+    A handler for GET requests for path /placements/{id}
+
+    :param request: request to be processed
+    :return: a response to request
+    """
+    placement_id = _get_placement_id(request)
+    placement_service = request.app['placement_service']  # type: AbsPlacementService
+
+    try:
+        return make_json_response(placement_service.view(placement_id))
+
+    except ServiceEntityResolutionError:
+        return make_json_response(
+            status=404,
+            content=ERROR_TEMPLATES[1005].to_dict()
+        )
+
+    except AuthInsufficientPrivilegesError:
+        error_dict = ERROR_TEMPLATES[2110].to_dict()
+
+        error_dict["user_message"] = error_dict["user_message"].format(action="viewing of placements data")
+
+        return make_json_response(
+            status=403,
+            content=error_dict
+        )
+
+
+async def placement_options_handler(request: web.Request) -> web.Response:
+    """
+    A handler for OPTIONS request for path /placements/{id}.
+
+    Returns a response that contains 'Allow' header with all allowed HTTP methods.
+
+    :param request: request to be handled
+    :return: a response to request
+    """
+    return web.Response(
+        body=None,
+        status=204,
+        headers={'Allow': 'GET, HEAD, OPTIONS'}
+    )

--- a/dpl/api/rest_api/rest_api_provider.py
+++ b/dpl/api/rest_api/rest_api_provider.py
@@ -1,0 +1,218 @@
+import time
+import logging
+import traceback
+import asyncio
+
+import aiohttp.web as web
+
+from dpl.auth.auth_context import AuthContext
+from dpl.auth.auth_service import (
+    AuthService,
+    AuthInvalidUserPasswordCombinationError
+)
+from dpl.api.cors_middleware import CorsMiddleware
+from dpl.api.api_errors import ERROR_TEMPLATES
+
+from .common import make_json_response
+from .json_decode_decorator import json_decode_decorator
+
+
+# Init logger
+LOGGER = logging.getLogger(__name__)
+
+
+@web.middleware
+async def middleware_process_exceptions(request: web.Request, handler) -> web.Response:
+    """
+    A function that wraps original request handler called
+    'handler' and processes any unhandled exceptions.
+
+    :param request: request to be handled
+    :return: a response to request
+    """
+    try:
+        return await handler(request)
+
+    except web.HTTPMethodNotAllowed:
+        error_dict = ERROR_TEMPLATES[1004].to_dict()
+        error_dict["devel_message"] = error_dict["devel_message"].format(method_name=request.method)
+
+        return make_json_response(
+            status=405,
+            content=error_dict
+        )
+
+    except web.HTTPNotFound:
+        return make_json_response(
+            status=404,
+            content=ERROR_TEMPLATES[1005].to_dict()
+        )
+
+    except Exception as e:
+        timestamp = time.monotonic()
+
+        LOGGER.error("Unhandled exception in request handling at %s: %s %s\n%s",
+                     timestamp, type(e), e, traceback.format_exc())
+
+        error_dict = ERROR_TEMPLATES[1003].to_dict()
+        error_dict["user_message"] = error_dict["user_message"].format(timestamp=timestamp)
+
+        return make_json_response(
+            status=500,
+            content=error_dict
+        )
+
+
+class RestApiProvider(object):
+    """
+    This class contains a logic of a REST API provider.
+
+    It declares some root-level logic and request handlers, sets
+    routes for subapps and assembles everything together
+
+    ..WARNING: May be removed in the future
+    """
+
+    def __init__(
+            self, things: web.Application, placements: web.Application, messages: web.Application,
+            auth_context: AuthContext, auth_service: AuthService
+    ):
+        self._things = things
+        self._placements = placements
+        self._messages = messages
+        self._auth_context = auth_context
+        self._auth_service = auth_service
+
+        self._loop = asyncio.get_event_loop()
+        self._handler = None
+        self._server = None
+
+        self._cors_middleware = CorsMiddleware(
+            is_enabled=True,
+            allowed_origin='*'
+        )
+
+        self._app = web.Application(
+            middlewares=(self._cors_middleware.handle, middleware_process_exceptions,)
+        )
+
+        context_data = {
+            'auth_service': auth_service,
+            'auth_context': auth_context
+        }
+
+        self._app.update(context_data)
+
+        self._app.add_subapp(
+            '/things/', self._things
+        )
+        self._app.add_subapp(
+            '/placements/', self._placements
+        )
+        self._app.add_subapp(
+            '/messages/', self._messages
+        )
+
+        self._router = self._app.router  # type: web.UrlDispatcher
+
+        self._router.add_get(path='/', handler=root_get_handler)
+        self._router.add_post(path='/auth', handler=auth_post_handler)
+        self._router.add_route(method='OPTIONS', path='/auth', handler=auth_options_handler)
+
+    async def create_server(self, host: str, port: int) -> None:
+        """
+        Factory function that creates fully-functional aiohttp server
+
+        :param host: a server hostname or address
+        :param port: a server port
+        :return: None
+        """
+        self._handler = self._app.make_handler(loop=self._loop)
+        self._server = await self._loop.create_server(self._handler, host, port)
+
+    async def shutdown_server(self) -> None:
+        """
+        Stop (shutdown) REST server gracefully.
+        More info is available here: http://aiohttp.readthedocs.io/en/stable/web.html#aiohttp-web-graceful-shutdown
+
+        :return: None
+        """
+        self._server.close()
+        await self._server.wait_closed()
+        await self._app.shutdown()  # fires on_shutdown signal (so does nothing now)
+        await self._handler.shutdown(60.0)
+        await self._app.cleanup()  # fires on_cleanup signal (so does nothing now)
+
+
+async def root_get_handler(self, request: web.Request) -> web.Response:
+    """
+    A handler for GET requests to path='/'
+
+    :param request: request to be processed
+    :return: a response to request
+    """
+    return make_json_response(
+        {"things": "/things/",
+         "auth": "/auth",
+         "messages": "/messages/",
+         "placements": "/placements/"}
+    )
+
+
+@json_decode_decorator
+async def auth_post_handler(request: web.Request) -> web.Response:
+    """
+    Primitive username and password validator
+
+    :param request: request to be processed
+    :return: a response to request
+    """
+    data = await request.json()
+
+    username = data.get("username", None)
+    password = data.get("password", None)
+
+    if username is None:
+        return make_json_response(
+            status=400,
+            content=ERROR_TEMPLATES[2000].to_dict()
+        )
+
+    if password is None:
+        return make_json_response(
+            status=400,
+            content=ERROR_TEMPLATES[2001].to_dict()
+        )
+
+    auth_service = request.app['auth_service']
+
+    try:
+        token = auth_service.request_access(
+            username, password,
+            client_info=request.headers.get('User-Agent'),
+            client_ip=request.transport.get_extra_info('peername')
+        )
+
+        return make_json_response({"message": "authorized", "token": token})
+
+    except AuthInvalidUserPasswordCombinationError:
+        return make_json_response(
+            status=401,
+            content=ERROR_TEMPLATES[2002].to_dict()
+        )
+
+
+async def auth_options_handler(request: web.Request) -> web.Response:
+    """
+    A handler for OPTIONS request for path /auth.
+
+    Returns a response that contains 'Allow' header with all allowed HTTP methods.
+
+    :param request: request to be handled
+    :return: a response to request
+    """
+    return web.Response(
+        body=None,
+        status=204,
+        headers={'Allow': 'POST, HEAD, OPTIONS'}
+    )

--- a/dpl/api/rest_api/restricted_access_decorator.py
+++ b/dpl/api/rest_api/restricted_access_decorator.py
@@ -1,0 +1,59 @@
+"""
+This module contains a definition of a restricted_access_decorator
+"""
+import functools
+
+import aiohttp.web as web
+
+from dpl.auth.auth_context import AuthContext
+from dpl.auth.exceptions import AuthInvalidTokenError
+from dpl.api.api_errors import ERROR_TEMPLATES
+from .common import RequestHandlerType, make_json_response
+
+
+def restricted_access(wrapped: RequestHandlerType) -> RequestHandlerType:
+    """
+    A decorator which wraps the specified callable (request
+    handler coroutine) with an auth-handling logic
+
+    :param wrapped: a request handler to be wrapped
+    :return: a request handler with an additional auth logic
+    """
+    @functools.wraps(wrapped)
+    async def _auth_wrapper(request: web.Request) -> web.Response:
+        """
+        This wrapper extracts an access token from a request
+        headers, extracts an instance of AuthContext from
+        a related aiohttp Application, passes an execution
+        to the real request handler and handles auth-related
+        errors
+
+        :param request: an HTTP request to be handled
+        :return: a response to the HTTP request
+        """
+        headers = request.headers  # type: dict
+
+        token = headers.get("Authorization", None)
+
+        if token is None:
+            return make_json_response(
+                status=401,
+                content=ERROR_TEMPLATES[2100].to_dict()
+            )
+
+        try:
+            auth_context = request.app['auth_context']  # type: AuthContext
+            assert isinstance(auth_context, AuthContext)
+
+            with auth_context(token=token):
+                return await wrapped(request)
+
+        except AuthInvalidTokenError:
+            error_dict = ERROR_TEMPLATES[2101].to_dict()
+
+            return make_json_response(
+                status=401,
+                content=error_dict
+            )
+
+    return _auth_wrapper

--- a/dpl/api/rest_api/things_subapp.py
+++ b/dpl/api/rest_api/things_subapp.py
@@ -1,0 +1,158 @@
+"""
+This module contains definitions of an aiohttp
+application controlling the /things/ route
+"""
+from typing import Mapping
+
+import aiohttp.web as web
+from dpl.utils import filtering
+from dpl.utils.empty_mapping import EMPTY_MAPPING
+
+from dpl.auth.exceptions import (
+    AuthInsufficientPrivilegesError
+)
+from dpl.services.abs_thing_service import (
+    AbsThingService,
+    ServiceEntityResolutionError
+)
+from dpl.api.api_errors import ERROR_TEMPLATES
+
+from .common import make_json_response
+from .restricted_access_decorator import restricted_access
+
+
+def build_things_subapp(
+        thing_service: AbsThingService,
+        additional_data: Mapping = EMPTY_MAPPING
+) -> web.Application:
+    """
+    A factory of aiohttp's Applications. Initializes and returns
+    an Application for managing of Things
+
+    :param thing_service: an instance of thing_service used for
+           managing of Things
+    :param additional_data: additional data to be saved in app's
+           context (data store)
+    :return: an instance of aiohttp Application
+    """
+    app = web.Application()
+    app['thing_service'] = thing_service
+    app.update(additional_data)
+    router = app.router
+
+    router.add_get(path='/', handler=things_get_handler)
+    router.add_route(method='OPTIONS', path='/', handler=things_options_handler)
+    router.add_get(path='/{id}', handler=thing_get_handler)
+    router.add_route(method='OPTIONS', path='/{id}', handler=thing_options_handler)
+
+    return app
+
+
+@restricted_access
+async def things_get_handler(request: web.Request) -> web.Response:
+    """
+    A handler for GET requests for path /things/
+
+    :param request: request to be processed
+    :return: a response to request
+    """
+    thing_service = request.app['thing_service']
+
+    try:
+        query_params = request.query
+
+        if 'placement' in query_params:
+            things = thing_service.select_by_placement(
+                query_params['placement']
+            )
+        else:
+            things = thing_service.view_all()
+
+        if 'type' in query_params:
+            things = filtering.filter_items(
+                things,
+                {'type': query_params['type']}
+            )
+
+        return make_json_response({"things": things})
+
+    except AuthInsufficientPrivilegesError:
+        error_dict = ERROR_TEMPLATES[2110].to_dict()
+
+        error_dict["user_message"] = error_dict["user_message"].format(action="viewing of things data")
+
+        return make_json_response(
+            status=403,
+            content=error_dict
+        )
+
+
+async def things_options_handler(request: web.Request) -> web.Response:
+    """
+    A handler for OPTIONS request for path /things/.
+
+    Returns a response that contains 'Allow' header with all allowed HTTP methods.
+
+    :param request: request to be handled
+    :return: a response to request
+    """
+    return web.Response(
+        body=None,
+        status=204,
+        headers={'Allow': 'GET, HEAD, OPTIONS'}
+    )
+
+
+def _get_thing_id(request: web.Request) -> str:
+    thing_id = request.match_info['id']
+
+    return thing_id
+
+
+@restricted_access
+async def thing_get_handler(request: web.Request) -> web.Response:
+    """
+    A handler for GET requests for path /things/{id}
+
+    :param request: request to be processed
+    :return: a response to request
+    """
+    thing_id = _get_thing_id(request)
+    thing_service = request.app['thing_service']
+
+    try:
+        thing = thing_service.view(thing_id)
+
+        return make_json_response(thing)
+
+    except ServiceEntityResolutionError:
+        return make_json_response(
+            status=404,
+            content=ERROR_TEMPLATES[1005].to_dict()
+        )
+
+    except AuthInsufficientPrivilegesError:
+        error_dict = ERROR_TEMPLATES[2110].to_dict()
+
+        error_dict["user_message"] = error_dict["user_message"].format(action="viewing of things data")
+
+        return make_json_response(
+            status=403,
+            content=error_dict
+        )
+
+
+async def thing_options_handler(request: web.Request) -> web.Response:
+    """
+    A handler for OPTIONS request for path /things/{id}.
+
+    Returns a response that contains 'Allow' header with all allowed HTTP methods.
+
+    :param request: request to be handled
+    :return: a response to request
+    """
+    return web.Response(
+        body=None,
+        status=204,
+        headers={'Allow': 'GET, HEAD, OPTIONS'}
+    )

--- a/dpl/api/rest_api_legacy.py
+++ b/dpl/api/rest_api_legacy.py
@@ -106,7 +106,7 @@ def json_decode_decorator(decorated_callable):
     return proxy
 
 
-class RestApi(object):
+class RestApiLegacy(object):
     """
     RestApi is a provider of REST API implementation which receives
     REST requests from clients and passes them to ApiGateway.

--- a/dpl/core/controller.py
+++ b/dpl/core/controller.py
@@ -132,7 +132,7 @@ class Controller(object):
         )  # type: ThingService
 
         self._api_gateway = api.ApiGateway(self._auth_service, self._thing_service, self._placement_service)
-        self._rest_api = api.RestApi(self._api_gateway)
+        self._rest_api = api.RestApiLegacy(self._api_gateway)
 
     def parse_arguments(self):
         """

--- a/dpl/core/controller.py
+++ b/dpl/core/controller.py
@@ -9,7 +9,6 @@ from sqlalchemy import create_engine
 import appdirs
 
 # Include DPL modules
-from dpl import api
 from dpl.core.configuration import Configuration
 from dpl.integrations.binding_bootstrapper import BindingBootstrapper
 
@@ -35,6 +34,11 @@ from dpl.auth.auth_context import AuthContext
 from dpl.auth.auth_aspect import AuthAspect
 
 from dpl.utils.simple_interceptor import SimpleInterceptor
+
+from dpl.api.rest_api.things_subapp import build_things_subapp
+from dpl.api.rest_api.placements_subapp import build_placements_subapp
+from dpl.api.rest_api.messages_subapp import build_messages_subapp
+from dpl.api.rest_api.rest_api_provider import RestApiProvider
 
 module_logger = logging.getLogger(__name__)
 dpl_root_logger = logging.getLogger(name='dpl')
@@ -131,8 +135,30 @@ class Controller(object):
             aspect=self._auth_aspect
         )  # type: ThingService
 
-        self._api_gateway = api.ApiGateway(self._auth_service, self._thing_service, self._placement_service)
-        self._rest_api = api.RestApiLegacy(self._api_gateway)
+        api_context_data = {'auth_context': self._auth_context}
+
+        self._rest_api_things = build_things_subapp(
+            thing_service=self._thing_service,
+            additional_data=api_context_data
+        )
+
+        self._rest_api_placements = build_placements_subapp(
+            placement_service=self._placement_service,
+            additional_data=api_context_data
+        )
+
+        self._rest_api_messages = build_messages_subapp(
+            thing_service=self._thing_service,
+            additional_data=api_context_data
+        )
+
+        self._rest_api = RestApiProvider(
+            things=self._rest_api_things,
+            placements=self._rest_api_placements,
+            messages=self._rest_api_messages,
+            auth_context=self._auth_context,
+            auth_service=self._auth_service
+        )
 
     def parse_arguments(self):
         """

--- a/tests/api/test_rest_api_provider.py
+++ b/tests/api/test_rest_api_provider.py
@@ -13,7 +13,7 @@ from dpl.api import ApiGateway
 from dpl.api import exceptions
 from dpl.api import api_errors
 
-from dpl.api.rest_api import RestApi
+from dpl.api.rest_api_legacy import RestApiLegacy
 
 
 class TestRestApiProvider(unittest.TestCase):
@@ -29,7 +29,7 @@ class TestRestApiProvider(unittest.TestCase):
         self.api_gateway_mock = mock.Mock(spec_set=ApiGateway)
 
         # create an instance of RestApi
-        self.rest_api_provider = RestApi(
+        self.rest_api_provider = RestApiLegacy(
             self.api_gateway_mock,
             self.loop
         )


### PR DESCRIPTION
Rewritten an REST API implementation. The following changes was made:
- a single REST API handler was split into several new entities (aiohttp Applications) by resources they control;
- abandoned an idea to declare request handlers as class methods;
- moved all dependencies to aiohttp Application's data storage;
- created builders for aiohttp Applications;
- refactored `restricted_access_decorator` and `json_decode_decorator`;
- performed a migration to the new REST API implementation in Controller.

This request closes #40 and unblocks #41.