### PR TITLE
Implemented /things/{id}/execute endoint

### DIFF
--- a/docs/source/api/handling_errors.rst
+++ b/docs/source/api/handling_errors.rst
@@ -272,9 +272,111 @@ HTTP status code: 403.
 Things
 ------
 
-FIXME
+.. _error_3100:
+
+Error 3100: Not an Actuator
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+This error can be thrown on attempts to send a command on execution
+to the Thing. It may indicate that:
+
+- the ``/execute`` sub-resource is not available for this instance;
+- this instance isn't capable of command execution.
+
+This error indicates some issue with the client-side code and should
+be fixed by client's developer. Do not allow to user to send any
+commands to the non-actuator objects.
+
+HTTP status code: 404.
+
+.. _error_3101:
+
+Error 3101: Missing 'command' value
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+This error can be thrown on attempts to send a command on execution
+to the Thing. It may indicate that:
+
+- the client application forgot to pass a ``command`` value in a
+  body of HTTP request;
+- the value of this header is not a string (i.e. is a number, null
+  or a value of some other type).
+
+This error indicates some issue with the client-side code and should
+be fixed by client's developer. You must to pass a valid ``command``
+value while sending of commands on execution to Actuators. To get
+more information about the ``/execute`` request and its format,
+please take a look into :ref:`things_executing_commands` section of
+documentation.
+
+HTTP status code: 400.
+
+.. _error_3102:
+
+Error 3102: Missing 'command_args' value
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+This error can be thrown on attempts to send a command on execution
+to the Thing. It may indicate that:
+
+- the client application forgot to pass a ``command_args`` value in a
+  body of HTTP request;
+- the value of the ``command_args`` key is not a mapping (dictionary).
+
+This error indicates some issue with the client-side code and should
+be fixed by client's developer. You must to pass a valid ``command_args``
+value while sending of commands on execution to Actuators. To get
+more information about the ``/execute`` request and its format,
+please take a look into :ref:`things_executing_commands` section of
+documentation.
+
+HTTP status code: 400.
+
+.. _error_3103:
+
+Error 3103: Unacceptable command arguments
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+This error can be thrown on attempts to send a command on execution
+to the Thing. It may indicate that:
+
+- the client application forgot to pass some non-optional argument in
+  the ``command_args`` field of a body of HTTP request;
+- the client application passed an unexpected extra (additional)
+  command argument in the ``command_args`` field of a body of HTTP request;
+- one of the command arguments haves an invalid type;
+- one of the command arguments haves an invalid value.
+
+This error indicates some issue with the client-side code and should
+be fixed by client's developer. You must to pass a valid ``command_args``
+value while sending of commands on execution to Actuators. To get
+more information about the ``/execute`` request and its format,
+please take a look into :ref:`things_executing_commands` section of
+documentation.
+
+HTTP status code: 400.
+
+
+Error 3110: Unsupported command
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+This error can be thrown on attempts to send a command on execution
+to the Thing. It may indicate that:
+
+- the specified instance of Actuator doesn't support the requested
+  command.
+
+This error indicates some issue with the client-side code and should
+be fixed by client's developer. You must to pass the name of a command
+which is supported by the specified Thing instance in ``command``
+field in request body. To get more information about the ``/execute``
+request and its format, please take a look into
+:ref:`things_executing_commands` section of documentation.
+
+HTTP status code: 400.
+
 
 Placements
 ----------
 
-FIXME
+There is no Placement-specific exceptions for now.

--- a/docs/source/api/rest_api.rst
+++ b/docs/source/api/rest_api.rst
@@ -218,6 +218,78 @@ To fetch a specific Thing, you need to perform the following request:
     Thing object.
 
 
+.. _things_executing_commands:
+
+Sending commands to a Thing
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Starting from the v0.3 of everpl it's possible to send commands to
+the Actuators - to the Things that are able to execute some commands.
+
+Each command can have its own set of arguments, the list of the allowed
+commands is specified in the ``commands`` field for each Actuator Thing.
+The list of available commands and their set of possible arguments is
+determined by the list of capabilities implemented by the specified Thing.
+
+To send a command to an Actuator Thing you need to send a POST request
+using an ``/execute`` sub-resource of a Thing in question:
+
+:URL structure:
+    ``BASE_URL/things/{id}/execute``
+
+:Method:
+    ``POST``
+
+:Headers:
+    :Authorization: ``your_auth_token_here``
+    :Content-Type: ``application/json``
+
+:Request Body:
+    .. code-block:: json
+
+        {
+	        "command": "the_name_of_the_command",
+	        "command_args": {}
+        }
+
+:Notes:
+    Replace ``{id}`` part of the URL with an identifier of requested
+    Thing object.
+
+The presence of the both ``command`` and ``command_args`` fields is mandatory.
+
+The value of the ``command`` field must to be a string - the name of the
+command to be executed; this value is must to be an element from the
+``commands`` field of the specified Thing.
+
+The value of the ``command_args`` field must to be a dictionary of keyword-
+arguments for the command with keys as strings and values as specified in
+the Thing's documentation. It's allowed to pass an empty dictionary as the
+value of the ``command_args`` field if there is no additional arguments needed
+for an execution of the specified command.
+
+In a case of success your command will be send on execution and you will get
+a similar response:
+
+:Status Code:
+    202
+
+:Headers:
+    :Content-Type: ``application/json``
+
+:Response Body:
+    .. code-block:: json
+
+        {
+	        "message": "accepted"
+        }
+
+In a case of an pre-execution (validation) error you will receive
+one of the responses listed in :doc:`./handling_errors` section of
+documentation. Possible errors: 1000, 1001, 1003, 1005, 2100, 2101,
+2110, 3100, 3101, 3102, 3103, 3110.
+
+
 Placements
 ----------
 

--- a/dpl/api/rest_api/things_subapp.py
+++ b/dpl/api/rest_api/things_subapp.py
@@ -233,3 +233,19 @@ async def thing_execute_post_handler(request: web.Request) -> web.Response:
             content=ERROR_TEMPLATES[3103].to_dict()
         )
 
+
+async def thing_execute_options_handler(request: web.Request) -> web.Response:
+    """
+    A handler for OPTIONS request for path /things/{id}/execute.
+
+    Returns a response that contains 'Allow' header with all allowed HTTP methods.
+
+    :param request: request to be handled
+    :return: a response to request
+    """
+    return web.Response(
+        body=None,
+        status=204,
+        headers={'Allow': 'POST, OPTIONS'}
+    )
+

--- a/dpl/api/rest_api/things_subapp.py
+++ b/dpl/api/rest_api/things_subapp.py
@@ -47,6 +47,8 @@ def build_things_subapp(
     router.add_route(method='OPTIONS', path='/', handler=things_options_handler)
     router.add_get(path='/{id}', handler=thing_get_handler)
     router.add_route(method='OPTIONS', path='/{id}', handler=thing_options_handler)
+    router.add_post(path='/{id}/execute', handler=thing_execute_post_handler)
+    router.add_route(method='OPTIONS', path='/{id}/execute', handler=thing_execute_options_handler)
 
     return app
 

--- a/dpl/api/rest_api/things_subapp.py
+++ b/dpl/api/rest_api/things_subapp.py
@@ -13,12 +13,15 @@ from dpl.auth.exceptions import (
 )
 from dpl.services.abs_thing_service import (
     AbsThingService,
-    ServiceEntityResolutionError
+    ServiceEntityResolutionError,
+    ServiceTypeError,
+    ServiceInvalidArgumentsError
 )
 from dpl.api.api_errors import ERROR_TEMPLATES
 
 from .common import make_json_response
 from .restricted_access_decorator import restricted_access
+from .json_decode_decorator import json_decode_decorator
 
 
 def build_things_subapp(
@@ -156,3 +159,77 @@ async def thing_options_handler(request: web.Request) -> web.Response:
         status=204,
         headers={'Allow': 'GET, HEAD, OPTIONS'}
     )
+
+
+@restricted_access
+@json_decode_decorator
+async def thing_execute_post_handler(request: web.Request) -> web.Response:
+    """
+    A handler for POST requests to the /things/{id}/execute
+    endpoint. Processes request on command execution for
+    actuators
+
+    :param request: request to be handled
+    :return: a response to request
+    """
+    thing_id = _get_thing_id(request)
+    thing_service = request.app['thing_service']  # type: AbsThingService
+
+    payload = await request.json()
+    command = payload.get('command')
+    command_args = payload.get('command_args')
+
+    if not isinstance(command, str):
+        return make_json_response(
+            status=400,
+            content=ERROR_TEMPLATES[3101].to_dict()
+        )
+
+    if not isinstance(command_args, Mapping):
+        return make_json_response(
+            status=400,
+            content=ERROR_TEMPLATES[3102].to_dict()
+        )
+
+    try:
+        thing_service.send_command(
+            to_actuator_id=thing_id,
+            command=command,
+            command_args=command_args
+        )
+
+        return make_json_response(
+            content={"message": "accepted"},
+            status=202
+        )
+
+    except ServiceEntityResolutionError:
+        return make_json_response(
+            status=404,
+            content=ERROR_TEMPLATES[1005].to_dict()
+        )
+
+    except AuthInsufficientPrivilegesError:
+        error_dict = ERROR_TEMPLATES[2110].to_dict()
+
+        error_dict["user_message"] = error_dict["user_message"].format(
+            action="sending commands to Actuators"
+        )
+
+        return make_json_response(
+            status=403,
+            content=error_dict
+        )
+
+    except ServiceTypeError:
+        return make_json_response(
+            status=404,
+            content=ERROR_TEMPLATES[3100].to_dict()
+        )
+
+    except ServiceInvalidArgumentsError:
+        return make_json_response(
+            status=400,
+            content=ERROR_TEMPLATES[3103].to_dict()
+        )
+

--- a/dpl/api/rest_api/things_subapp.py
+++ b/dpl/api/rest_api/things_subapp.py
@@ -15,7 +15,8 @@ from dpl.services.abs_thing_service import (
     AbsThingService,
     ServiceEntityResolutionError,
     ServiceTypeError,
-    ServiceInvalidArgumentsError
+    ServiceInvalidArgumentsError,
+    ServiceUnsupportedCommandError
 )
 from dpl.api.api_errors import ERROR_TEMPLATES
 
@@ -233,6 +234,12 @@ async def thing_execute_post_handler(request: web.Request) -> web.Response:
         return make_json_response(
             status=400,
             content=ERROR_TEMPLATES[3103].to_dict()
+        )
+
+    except ServiceUnsupportedCommandError:
+        return make_json_response(
+            status=400,
+            content=ERROR_TEMPLATES[3110].to_dict()
         )
 
 

--- a/dpl/internal_config/api_errors.json
+++ b/dpl/internal_config/api_errors.json
@@ -54,6 +54,31 @@
       "error_id": 2110,
       "devel_message": "Permission Denied",
       "user_message": "Permission Denied.\nYou are not authorized to {action}. Please, contact an administrator of this platform instance"
+    },
+    {
+      "error_id": 3100,
+      "devel_message": "Not an Actuator",
+      "user_message": "Unsupported client application.\nPlease, contact the developer of this client application"
+    },
+    {
+      "error_id": 3101,
+      "devel_message": "Missing 'command' value",
+      "user_message": "Unsupported client application.\nPlease, contact the developer of this client application"
+    },
+    {
+      "error_id": 3102,
+      "devel_message": "Missing 'command_args' value",
+      "user_message": "Unsupported client application.\nPlease, contact the developer of this client application"
+    },
+    {
+      "error_id": 3103,
+      "devel_message": "Unacceptable command arguments",
+      "user_message": "Unsupported client application.\nPlease, contact the developer of this client application"
+    },
+    {
+      "error_id": 3110,
+      "devel_message": "Unsupported command",
+      "user_message": "Unsupported client application.\nPlease, contact the developer of this client application"
     }
   ]
 }


### PR DESCRIPTION
Implemented the new endpoint which will allow to send commands on execution to any Actuator Thing. Prepared corresponding documentation with a notes about the usage and possible errors.

Closes #53 