### PR TITLE
Refactoring for Things

### DIFF
--- a/dpl/dtos/actuator_dto.py
+++ b/dpl/dtos/actuator_dto.py
@@ -20,6 +20,7 @@ ActuatorDto = ThingDto
 @build_dto.register(AbsActuator)
 def _(thing: AbsActuator) -> ActuatorDto:
     result = {
+        'state': thing.state.name,
         'commands': thing.commands,
         'is_active': thing.is_active
     }

--- a/dpl/dtos/actuator_dto.py
+++ b/dpl/dtos/actuator_dto.py
@@ -11,14 +11,14 @@ to the ActuatorDto
 
 from .dto_builder import build_dto
 from .thing_dto import ThingDto, build_thing_dto
-from dpl.things.actuator import Actuator
+from dpl.integrations.abs_actuator import AbsActuator
 
 
 ActuatorDto = ThingDto
 
 
-@build_dto.register(Actuator)
-def _(thing: Actuator) -> ActuatorDto:
+@build_dto.register(AbsActuator)
+def _(thing: AbsActuator) -> ActuatorDto:
     result = {
         'commands': thing.commands,
         'is_active': thing.is_active

--- a/dpl/dtos/thing_dto.py
+++ b/dpl/dtos/thing_dto.py
@@ -41,7 +41,6 @@ ThingDto = BaseDto
 def build_thing_dto(thing: Thing) -> ThingDto:
     result = {
         'id': thing.domain_id,
-        'state': thing.state.name,
         'is_enabled': thing.is_enabled,
         'is_available': thing.is_available,
         'last_updated': thing.last_updated

--- a/dpl/integrations/abs_actuator.py
+++ b/dpl/integrations/abs_actuator.py
@@ -24,22 +24,26 @@ class AbsActuator(Thing, IActuator, IState):
 
     - it can be in one of two states: 'activated' or 'deactivated';
     - 'activation' is a switching of a device to some specific active state
-      (like 'on' for LightBulb, 'opened' for Door and 'capturing' for Camera and
-      'playing' for Player);
-    - 'deactivation' is a switching of a device to some specific non-active state
-      (like 'off' for LightBulb, 'closed' for Door and 'idle' for Camera and
-      'stopped'/'paused' for Player);
+      (like 'on' for LightBulb, 'opened' for Door and 'capturing' for Camera
+      and 'playing' for Player);
+    - 'deactivation' is a switching of a device to some specific non-active
+      state (like 'off' for LightBulb, 'closed' for Door and 'idle' for Camera
+      and 'stopped'/'paused' for Player);
     - it can be toggled between those to states;
     - it provides a list of available commands;
     - each available command can be executed;
-    - if command can't be executed for any reason, corresponding method raises an
-      exception (FIXME: CC9: or returns an error code???)
+    - if command can't be executed for any reason, corresponding method raises
+      an exception (FIXME: CC9: or returns an error code???)
     """
-    def __init__(self, domain_id: TDomainId, con_instance: Connection, con_params: dict, metadata: dict = None):
+    def __init__(
+            self, domain_id: TDomainId,
+            con_instance: Connection, con_params: dict,
+            metadata: dict = None
+    ):
         """
-        Constructor of a Thing. Receives an instance of Connection and some specific
-        parameters to use it properly. Also can receive some metadata to be stored like
-        object placement, description or user-friendly name.
+        Constructor of a Thing. Receives an instance of Connection and some
+        specific parameters to use it properly. Also can receive some metadata
+        to be stored like object placement, description or user-friendly name.
 
         :param domain_id: a unique identifier of this Thing
         :param con_instance: an instance of connection to be used
@@ -74,7 +78,8 @@ class AbsActuator(Thing, IActuator, IState):
     @property
     def commands(self) -> Iterable[str]:
         """
-        Returns a list of available commands. Must be overridden in derivative classes.
+        Returns a list of available commands. Must be overridden in derivative
+        classes.
 
         :return: a tuple of command names (strings)
         """
@@ -96,7 +101,9 @@ class AbsActuator(Thing, IActuator, IState):
                 can't be executed
         """
         if command not in self.commands:
-            raise UnsupportedCommandError("Unsupported command passed: {0}".format(command))
+            raise UnsupportedCommandError(
+                "Unsupported command passed: {0}".format(command)
+            )
 
         command_method = getattr(self, command)
 

--- a/dpl/integrations/abs_actuator.py
+++ b/dpl/integrations/abs_actuator.py
@@ -15,7 +15,7 @@ from dpl.things.capabilities.i_actuator import (
 from dpl.things.thing import Thing, TDomainId, Connection
 
 
-class Actuator(Thing, IActuator, IState):
+class AbsActuator(Thing, IActuator, IState):
     """
     Actuator is an abstraction of devices that can 'act', perform some commands
     and change their states after that.
@@ -51,7 +51,7 @@ class Actuator(Thing, IActuator, IState):
         self._really_internal_state_value = self.States.unknown
 
     @property
-    def _state(self) -> 'Actuator.States':
+    def _state(self) -> 'AbsActuator.States':
         """
         Return a really_internal_state_value
 
@@ -60,7 +60,7 @@ class Actuator(Thing, IActuator, IState):
         return self._really_internal_state_value
 
     @_state.setter
-    def _state(self, new_value: 'Actuator.States') -> None:
+    def _state(self, new_value: 'AbsActuator.States') -> None:
         """
         Internal setter for a really_internal_state_value that can be used to
         set a new state value and update last_updated time

--- a/dpl/integrations/abs_player.py
+++ b/dpl/integrations/abs_player.py
@@ -4,10 +4,10 @@ from typing import Tuple
 
 # Include 3rd-party modules
 # Include DPL modules
-from dpl.things import Actuator
+from .abs_actuator import AbsActuator
 
 
-class Player(Actuator):
+class AbsPlayer(AbsActuator):
     """
     Player is an abstraction of basic player device or application. It can be in
     one of three states: 'stopped', 'playing' and 'paused'.

--- a/dpl/integrations/abs_player.py
+++ b/dpl/integrations/abs_player.py
@@ -9,8 +9,8 @@ from .abs_actuator import AbsActuator
 
 class AbsPlayer(AbsActuator):
     """
-    Player is an abstraction of basic player device or application. It can be in
-    one of three states: 'stopped', 'playing' and 'paused'.
+    Player is an abstraction of basic player device or application. It can be
+    in one of three states: 'stopped', 'playing' and 'paused'.
     """
     class States(Enum):
         stopped = 0
@@ -21,7 +21,8 @@ class AbsPlayer(AbsActuator):
     @property
     def commands(self) -> Tuple[str, ...]:
         """
-        Returns a list of available commands. Must be overridden in derivative classes.
+        Returns a list of available commands. Must be overridden in derivative
+        classes.
 
         :return: a tuple of command names (strings)
         """
@@ -54,8 +55,8 @@ class AbsPlayer(AbsActuator):
 
     def play(self, *args, **kwargs) -> None:
         """
-        Starts playing and switches the object to the 'playing' state. Additional parameters
-        like track name or URL can be provided.
+        Starts playing and switches the object to the 'playing' state.
+        Additional parameters like track name or URL can be provided.
 
         :param args: positional parameters
         :param kwargs: keyword parameters

--- a/dpl/integrations/abs_slider.py
+++ b/dpl/integrations/abs_slider.py
@@ -4,10 +4,10 @@ from typing import Tuple
 
 # Include 3rd-party modules
 # Include DPL modules
-from dpl.things import Actuator
+from .abs_actuator import AbsActuator
 
 
-class Slider(Actuator):
+class AbsSlider(AbsActuator):
     """
     Slider is an abstraction of real-life object, that can be in one of two
     stable states: 'opened' and 'closed' and also can be two transition states:

--- a/dpl/integrations/abs_slider.py
+++ b/dpl/integrations/abs_slider.py
@@ -23,7 +23,8 @@ class AbsSlider(AbsActuator):
     @property
     def commands(self) -> Tuple[str, ...]:
         """
-        Returns a list of available commands. Must be overridden in derivative classes.
+        Returns a list of available commands. Must be overridden in derivative
+        classes.
 
         :return: a tuple of command names (strings)
         """
@@ -56,8 +57,9 @@ class AbsSlider(AbsActuator):
 
     def open(self) -> None:
         """
-        Switches an object to the 'opening' and then 'opened' state if its current state
-        is 'undefined', 'closed' or 'closing'. Command must be ignored otherwise.
+        Switches an object to the 'opening' and then 'opened' state if its
+        current state is 'undefined', 'closed' or 'closing'. Command must be
+        ignored otherwise.
 
         :return: None
         """
@@ -65,8 +67,9 @@ class AbsSlider(AbsActuator):
 
     def close(self) -> None:
         """
-        Switches an object to the 'closing' and then 'closed' state if its current state
-        is 'undefined', 'opened' or 'opening'. Command must be ignored otherwise.
+        Switches an object to the 'closing' and then 'closed' state if its
+        current state is 'undefined', 'opened' or 'opening'. Command must be
+        ignored otherwise.
 
         :return: None
         """

--- a/dpl/integrations/abs_switch.py
+++ b/dpl/integrations/abs_switch.py
@@ -9,8 +9,9 @@ from .abs_actuator import AbsActuator
 
 class AbsSwitch(AbsActuator):
     """
-    Switch is an abstraction of objects with two only available states: 'on' and 'off'.
-    Like simple light bulb, power socket, relay or fan with uncontrollable speed.
+    Switch is an abstraction of objects with two only available states: 'on'
+    and 'off'. Like simple light bulb, power socket, relay or fan with
+    uncontrollable speed.
     """
     class States(Enum):
         on = True
@@ -20,7 +21,8 @@ class AbsSwitch(AbsActuator):
     @property
     def commands(self) -> Tuple[str, ...]:
         """
-        Returns a list of available commands. Must be overridden in derivative classes.
+        Returns a list of available commands. Must be overridden in derivative
+        classes.
 
         :return: a tuple of command names (strings)
         """

--- a/dpl/integrations/abs_switch.py
+++ b/dpl/integrations/abs_switch.py
@@ -4,10 +4,10 @@ from typing import Tuple
 
 # Include 3rd-party modules
 # Include DPL modules
-from dpl.things import Actuator
+from .abs_actuator import AbsActuator
 
 
-class Switch(Actuator):
+class AbsSwitch(AbsActuator):
     """
     Switch is an abstraction of objects with two only available states: 'on' and 'off'.
     Like simple light bulb, power socket, relay or fan with uncontrollable speed.

--- a/dpl/service_impls/thing_service.py
+++ b/dpl/service_impls/thing_service.py
@@ -1,14 +1,20 @@
 from typing import Optional, Mapping, Any
 
 from dpl.model.domain_id import TDomainId
-from dpl.things.actuator import Actuator, UnsupportedCommandError, UnacceptableCommandArgumentsError
+from dpl.integrations.abs_actuator import (
+    AbsActuator, UnsupportedCommandError, UnacceptableCommandArgumentsError
+)
 from dpl.dtos.thing_dto import ThingDto
 # noinspection PyUnresolvedReferences
 from dpl.dtos.actuator_dto import ActuatorDto
 from dpl.dtos.dto_builder import build_dto
-from dpl.services.abs_thing_service import AbsThingService, \
-    ServiceEntityResolutionError, ServiceTypeError, ServiceInvalidArgumentsError, \
+from dpl.services.abs_thing_service import (
+    AbsThingService,
+    ServiceEntityResolutionError,
+    ServiceTypeError,
+    ServiceInvalidArgumentsError,
     ServiceUnsupportedCommandError
+)
 
 from dpl.repos.abs_thing_repository import AbsThingRepository
 
@@ -120,7 +126,7 @@ class ThingService(AbsThingService):
                 command is not supported by this instance of Thing
         :raises ServiceUnsupportedCommandError:
         """
-        thing = self._things.load(to_actuator_id)  # type: Actuator
+        thing = self._things.load(to_actuator_id)  # type: AbsActuator
 
         if thing is None:
             raise ServiceEntityResolutionError(

--- a/dpl/service_impls/thing_service.py
+++ b/dpl/service_impls/thing_service.py
@@ -81,7 +81,9 @@ class ThingService(AbsThingService):
         # FIXME: Handle exceptions caused by link breakages
         self._things.delete(domain_id)
 
-    def select_by_placement(self, placement_id: Optional[TDomainId]):  # -> Collection[ThingDto]:
+    def select_by_placement(
+            self, placement_id: Optional[TDomainId]
+    ):  # -> Collection[ThingDto]:
         """
         Selects all Things that are physically present in the
         specified Placement
@@ -96,7 +98,10 @@ class ThingService(AbsThingService):
             build_dto(i) for i in self._things.select_by_placement(placement_id)
         ]
 
-    def send_command(self, to_actuator_id: TDomainId, command: str, command_args: Mapping[str, Any]) -> None:
+    def send_command(
+            self, to_actuator_id: TDomainId,
+            command: str, command_args: Mapping[str, Any]
+    ) -> None:
         """
         Allows to send a command to Actuator or any other Thing
         which has an 'execute' method implemented.

--- a/dpl/things/__init__.py
+++ b/dpl/things/__init__.py
@@ -1,7 +1,4 @@
 from .thing import Thing
-from .actuator import Actuator
-from .switch import Switch
-from .slider import Slider
-from .player import Player
+from . import capabilities
 
-__all__ = ["Thing", "Actuator", "Switch", "Slider", "Player"]
+__all__ = ["Thing", "capabilities"]

--- a/dpl/things/actuator.py
+++ b/dpl/things/actuator.py
@@ -7,27 +7,12 @@ from dpl.utils.empty_mapping import EMPTY_MAPPING
 
 # Include DPL modules
 from dpl.things.capabilities.i_state import IState
-from dpl.things.capabilities.i_actuator import IActuator
+from dpl.things.capabilities.i_actuator import (
+    IActuator,
+    UnsupportedCommandError,
+    UnacceptableCommandArgumentsError
+)
 from dpl.things.thing import Thing, TDomainId, Connection
-
-
-class UnsupportedCommandError(ValueError):
-    """
-    An exceptions to be raised if the specified command
-    is not supported by this instance of Thing
-    """
-    pass
-
-
-class UnacceptableCommandArgumentsError(Exception):
-    """
-    An exception to be raised if at least one of the specified
-    command arguments has an unacceptable type or if there is
-    an incorrect set of arguments passed (i.e. if one of the
-    mandatory arguments is missing or if one of the specified
-    arguments is extra and isn't related to the specified command)
-    """
-    pass
 
 
 class Actuator(Thing, IActuator, IState):

--- a/dpl/things/capabilities/i_actuator.py
+++ b/dpl/things/capabilities/i_actuator.py
@@ -5,6 +5,25 @@ from dpl.utils.empty_mapping import EMPTY_MAPPING
 from .i_state import IState
 
 
+class UnsupportedCommandError(ValueError):
+    """
+    An exceptions to be raised if the specified command
+    is not supported by this instance of Thing
+    """
+    pass
+
+
+class UnacceptableCommandArgumentsError(Exception):
+    """
+    An exception to be raised if at least one of the specified
+    command arguments has an unacceptable type or if there is
+    an incorrect set of arguments passed (i.e. if one of the
+    mandatory arguments is missing or if one of the specified
+    arguments is extra and isn't related to the specified command)
+    """
+    pass
+
+
 class IActuator(IState):
     """
     IActuator capability is usually mapped to Actuators.

--- a/dpl/things/thing.py
+++ b/dpl/things/thing.py
@@ -110,6 +110,7 @@ class Thing(BaseEntity, IEnabled, IAvailable, ILastUpdated):
 
         :return: None
         """
+        # FIXME: CC40: Define a more specific exception for such situations
         if not self.is_available:
             raise RuntimeError("This thing is unavailable and can't be used at this time")
 

--- a/dpl/things/thing.py
+++ b/dpl/things/thing.py
@@ -70,8 +70,8 @@ class Thing(BaseEntity, IEnabled, IAvailable, ILastUpdated):
         """
         super().__init__(domain_id)
 
-        # Connection params must be saved manually in derived classes
-        # Connection params must be parsed and saved manually in derived classes
+        self._con_instance = con_instance
+        self._con_params = con_params
         self._metadata = deepcopy(metadata)
         self._last_updated = time.time()
         self._is_enabled = False

--- a/dpl/things/thing.py
+++ b/dpl/things/thing.py
@@ -18,9 +18,9 @@ class Thing(BaseEntity, IEnabled, IAvailable, ILastUpdated):
     """
     Thing is a base class for all connected devices in the system.
 
-    Every implementation of Thing is an abstraction of real-life objects, devices,
-    items, things that uses some specific protocol (connection) and can communicate
-    with the system in any way.
+    Every implementation of Thing is an abstraction of real-life objects,
+    devices, items, things that uses some specific protocol (connection) and
+    can communicate with the system in any way.
 
     Specific implementations of things are grouped into 'integrations'.
 
@@ -30,31 +30,34 @@ class Thing(BaseEntity, IEnabled, IAvailable, ILastUpdated):
     - a current state of thing is always updated and corresponds to the current
       state of real object at the moment;
     - connection lost is indicated in specific property;
-    - if connection is lost then the last known state of the object must be displayed
-      in corresponding property;
-    - every implementation of a thing must notify all subscribers about the changes of
-      thing state and connection state;
+    - if connection is lost then the last known state of the object must be
+      displayed in the corresponding property;
+    - every implementation of a thing must notify all subscribers about the
+      changes of thing state and connection state;
     - each thing has and additional 'is_available' property;
     - each thing can be 'enabled' and 'disabled';
-    - 'disabled' thing doesn't update its state and doesn't try to support underlying
-      connection alive;
+    - 'disabled' thing doesn't update its state and doesn't try to support
+      underlying connection alive;
     - 'enabled' thing tries to keep thing state updated;
-    - 'is_available' property indicates that a communication with this thing can be
-      performed;
-    - 'is_available' is True **only** if thing is enabled **and** connection is not lost;
-    - additional (optional) information about the object can be placed in so-called 'metadata';
-    - usually the following metadata is saved: thing ID, user-friendly name, thing placement
-      (position) information and some description.
+    - 'is_available' property indicates that a communication with this thing
+      can be performed;
+    - 'is_available' is True **only** if thing is enabled **and** connection is
+      not lost;
+    - additional (optional) information about the object can be placed in
+      so-called 'metadata';
+    - usually the following metadata is saved: thing ID, user-friendly name,
+      thing placement (position) information and some description.
 
-    Derived classes are allowed to define additional methods and properties like
-    'current_track', 'play' and 'stop' for player. Or 'on'/'off' for lighting, etc.
+    Derived classes are allowed to define additional methods and properties
+    like 'current_track', 'play' and 'stop' for player. Or 'on'/'off' for
+    lighting, etc.
     """
 
     def __init__(self, domain_id: TDomainId, con_instance: Connection, con_params: dict, metadata: dict = None):
         """
-        Constructor of a Thing. Receives an instance of Connection and some specific
-        parameters to use it properly. Also can receive some metadata to be stored like
-        object placement, description or user-friendly name.
+        Constructor of a Thing. Receives an instance of Connection and some
+        specific parameters to use it properly. Also can receive some metadata
+        to be stored like object placement, description or user-friendly name.
 
         :param domain_id: a unique identifier of this Thing
         :param con_instance: an instance of connection to be used

--- a/dpl/things/thing.py
+++ b/dpl/things/thing.py
@@ -53,7 +53,11 @@ class Thing(BaseEntity, IEnabled, IAvailable, ILastUpdated):
     lighting, etc.
     """
 
-    def __init__(self, domain_id: TDomainId, con_instance: Connection, con_params: dict, metadata: dict = None):
+    def __init__(
+            self, domain_id: TDomainId,
+            con_instance: Connection, con_params: dict,
+            metadata: dict = None
+    ):
         """
         Constructor of a Thing. Receives an instance of Connection and some
         specific parameters to use it properly. Also can receive some metadata

--- a/everpli_dummy/dummy_player.py
+++ b/everpli_dummy/dummy_player.py
@@ -12,15 +12,19 @@ class DummyPlayer(AbsPlayer):
     """
     A reference implementation of Player
     """
-    def __init__(self, domain_id: TDomainId, con_instance: DummyConnection, con_params: dict, metadata: dict):
+    def __init__(
+            self, domain_id: TDomainId, con_instance: DummyConnection,
+            con_params: dict, metadata: dict
+    ):
         """
-        Constructor. Receives an instance of DummyConnection and a prefix to be printed
-        in con_params.
+        Constructor. Receives an instance of DummyConnection and a prefix to
+        be printed in con_params.
 
         :param domain_id: a unique identifier of this Thing
         :param con_instance: an instance of connection to be used
         :param con_params: a dict which contains connection access params
-        :param metadata: some additional data that will be saved to 'metadata' property
+        :param metadata: some additional data that will be saved to 'metadata'
+               property
         """
         super().__init__(domain_id, con_instance, con_params, metadata)
 
@@ -29,7 +33,8 @@ class DummyPlayer(AbsPlayer):
         try:
             self._print_prefix = con_params[key_name]
         except KeyError:
-            raise ValueError("Invalid connection params passed: {0} parameter is missing".format(key_name))
+            raise ValueError("Invalid connection params passed: "
+                             "{0} parameter is missing".format(key_name))
 
         self._con_instance = con_instance
 
@@ -75,14 +80,18 @@ class DummyPlayer(AbsPlayer):
 
     def play(self, song_name: str = None) -> None:
         """
-        Starts playing and switches the object to the 'playing' state. Additional parameters
-        like track name or URL can be provided.
+        Starts playing and switches the object to the 'playing' state.
+        Additional parameters like track name or URL can be provided.
 
-        :param song_name: song name to be played (or URL, or ID, or playlist position, etc.)
+        :param song_name: song name to be played (or URL, or ID, or playlist
+               position, etc.)
         :return: None
         """
         self._check_is_available()
-        self._con_instance.print(self._print_prefix, "Player is playing {0}".format(song_name))
+        self._con_instance.print(
+            self._print_prefix,
+            "Player is playing {0}".format(song_name)
+        )
         self._state = self.States.playing
 
     def stop(self) -> None:
@@ -108,7 +117,8 @@ class DummyPlayer(AbsPlayer):
 
 class DummyPlayerFactory(ThingFactory):
     """
-    DummyPlayerFactory is a class that is responsible for building of DummyPlayers
+    DummyPlayerFactory is a class that is responsible for building of
+    DummyPlayers
     """
     @staticmethod
     def build(*args, **kwargs) -> DummyPlayer:

--- a/everpli_dummy/dummy_player.py
+++ b/everpli_dummy/dummy_player.py
@@ -2,13 +2,13 @@
 # Include 3rd-party modules
 
 # Include DPL modules
-from dpl.things import Player
+from dpl.integrations.abs_player import AbsPlayer
 from dpl.integrations import ThingFactory, ThingRegistry
 from dpl.model.domain_id import TDomainId
 from .dummy_connection import DummyConnection
 
 
-class DummyPlayer(Player):
+class DummyPlayer(AbsPlayer):
     """
     A reference implementation of Player
     """
@@ -34,7 +34,7 @@ class DummyPlayer(Player):
         self._con_instance = con_instance
 
     @property
-    def state(self) -> Player.States:
+    def state(self) -> AbsPlayer.States:
         """
         Return a current state of the Thing
 

--- a/everpli_dummy/dummy_slider.py
+++ b/everpli_dummy/dummy_slider.py
@@ -3,14 +3,14 @@ import time
 
 # Include 3rd-party modules
 # Include DPL modules
-from dpl.things import Slider
+from dpl.integrations.abs_slider import AbsSlider
 from dpl.integrations import ThingFactory, ThingRegistry
 from dpl.model.domain_id import TDomainId
 
 from .dummy_connection import DummyConnection
 
 
-class DummySlider(Slider):
+class DummySlider(AbsSlider):
     """
     A reference implementation of slider
     """
@@ -38,7 +38,7 @@ class DummySlider(Slider):
         self._con_instance = con_instance
 
     @property
-    def state(self) -> Slider.States:
+    def state(self) -> AbsSlider.States:
         """
         Return a current state of the Thing
 

--- a/everpli_dummy/dummy_slider.py
+++ b/everpli_dummy/dummy_slider.py
@@ -16,15 +16,20 @@ class DummySlider(AbsSlider):
     """
     __SWITCH_DELAY = 1  # second
 
-    def __init__(self, domain_id: TDomainId, con_instance: DummyConnection, con_params: dict, metadata: dict):
+    def __init__(
+            self, domain_id: TDomainId,
+            con_instance: DummyConnection, con_params: dict,
+            metadata: dict
+    ):
         """
-        Constructor. Receives an instance of DummyConnection and a prefix to be printed
-        in con_params.
+        Constructor. Receives an instance of DummyConnection and a prefix to
+        be printed in con_params.
 
         :param domain_id: a unique identifier of this Thing
         :param con_instance: an instance of connection to be used
         :param con_params: a dict which contains connection access params
-        :param metadata: some additional data that will be saved to 'metadata' property
+        :param metadata: some additional data that will be saved to 'metadata'
+               property
         """
         super().__init__(domain_id, con_instance, con_params, metadata)
 
@@ -33,7 +38,10 @@ class DummySlider(AbsSlider):
         try:
             self._print_prefix = con_params[key_name]
         except KeyError:
-            raise ValueError("Invalid connection params passed: {0} parameter is missing".format(key_name))
+            raise ValueError(
+                "Invalid connection params passed: "
+                "{0} parameter is missing".format(key_name)
+            )
 
         self._con_instance = con_instance
 
@@ -79,17 +87,20 @@ class DummySlider(AbsSlider):
 
     def open(self) -> None:
         """
-        Switches an object to the 'opening' and then 'opened' state if its current state
-        is 'undefined', 'closed' or 'closing'. Command must be ignored otherwise.
+        Switches an object to the 'opening' and then 'opened' state if its
+        current state is 'undefined', 'closed' or 'closing'. Command must be
+        ignored otherwise.
 
         :return: None
         """
         self._check_is_available()
 
-        if self._state == self.States.opening or self._state == self.States.opened:
+        if self._state == self.States.opening or \
+                self._state == self.States.opened:
             pass
         else:
-            self._con_instance.print(self._print_prefix, "Switch is opening...")
+            self._con_instance.print(self._print_prefix,
+                                     "Switch is opening...")
             self._state = self.States.opening
 
             time.sleep(self.__SWITCH_DELAY)
@@ -99,17 +110,20 @@ class DummySlider(AbsSlider):
 
     def close(self) -> None:
         """
-        Switches an object to the 'closing' and then 'closed' state if its current state
-        is 'undefined', 'opened' or 'opening'. Command must be ignored otherwise.
+        Switches an object to the 'closing' and then 'closed' state if its
+        current state is 'undefined', 'opened' or 'opening'. Command must be
+        ignored otherwise.
 
         :return: None
         """
         self._check_is_available()
 
-        if self._state == self.States.closing or self._state == self.States.closed:
+        if self._state == self.States.closing or \
+                self._state == self.States.closed:
             pass
         else:
-            self._con_instance.print(self._print_prefix, "Switch is closing...")
+            self._con_instance.print(self._print_prefix,
+                                     "Switch is closing...")
             self._state = self.States.closing
 
             time.sleep(self.__SWITCH_DELAY)
@@ -120,7 +134,8 @@ class DummySlider(AbsSlider):
 
 class DummySliderFactory(ThingFactory):
     """
-    DummySliderFactory is a class that is responsible for building of DummySliders
+    DummySliderFactory is a class that is responsible for building of
+    DummySliders
     """
     @staticmethod
     def build(*args, **kwargs) -> DummySlider:

--- a/everpli_dummy/dummy_switch.py
+++ b/everpli_dummy/dummy_switch.py
@@ -10,15 +10,20 @@ from .dummy_connection import DummyConnection
 
 
 class DummySwitch(AbsSwitch):
-    def __init__(self, domain_id: TDomainId, con_instance: DummyConnection, con_params: dict, metadata: dict):
+    def __init__(
+            self, domain_id: TDomainId,
+            con_instance: DummyConnection, con_params: dict,
+            metadata: dict
+    ):
         """
-        Constructor. Receives an instance of DummyConnection and a prefix to be printed
-        in con_params.
+        Constructor. Receives an instance of DummyConnection and a prefix to
+        be printed in con_params.
 
         :param domain_id: a unique identifier of this Thing
         :param con_instance: an instance of connection to be used
         :param con_params: a dict which contains connection access params
-        :param metadata: some additional data that will be saved to 'metadata' property
+        :param metadata: some additional data that will be saved to 'metadata'
+               property
         """
         super().__init__(domain_id, con_instance, con_params, metadata)
 
@@ -27,7 +32,8 @@ class DummySwitch(AbsSwitch):
         try:
             self._print_prefix = con_params[key_name]
         except KeyError:
-            raise ValueError("Invalid connection params passed: {0} parameter is missing".format(key_name))
+            raise ValueError("Invalid connection params passed: "
+                             "{0} parameter is missing".format(key_name))
 
         self._con_instance = con_instance
 
@@ -94,7 +100,8 @@ class DummySwitch(AbsSwitch):
 
 class DummySwitchFactory(ThingFactory):
     """
-    DummySliderFactory is a class that is responsible for building of DummySliders
+    DummySliderFactory is a class that is responsible for building of
+    DummySliders
     """
     @staticmethod
     def build(*args, **kwargs) -> DummySwitch:

--- a/everpli_dummy/dummy_switch.py
+++ b/everpli_dummy/dummy_switch.py
@@ -2,14 +2,14 @@
 # Include 3rd-party modules
 
 # Include DPL modules
-from dpl.things import Switch
+from dpl.integrations.abs_switch import AbsSwitch
 from dpl.integrations import ThingFactory, ThingRegistry
 from dpl.model.domain_id import TDomainId
 
 from .dummy_connection import DummyConnection
 
 
-class DummySwitch(Switch):
+class DummySwitch(AbsSwitch):
     def __init__(self, domain_id: TDomainId, con_instance: DummyConnection, con_params: dict, metadata: dict):
         """
         Constructor. Receives an instance of DummyConnection and a prefix to be printed
@@ -32,7 +32,7 @@ class DummySwitch(Switch):
         self._con_instance = con_instance
 
     @property
-    def state(self) -> Switch.States:
+    def state(self) -> AbsSwitch.States:
         """
         Return a current state of the Thing
 

--- a/tests/integrations/base_test_suite/base_test_actuator.py
+++ b/tests/integrations/base_test_suite/base_test_actuator.py
@@ -6,7 +6,7 @@ import uuid
 
 # Include 3rd-party modules
 # Include DPL modules
-from dpl.things import Actuator
+from dpl.integrations.abs_actuator import AbsActuator
 from dpl.connections import Connection
 
 
@@ -35,7 +35,7 @@ class BaseTestActuator(unittest.TestCase):
         raise NotImplementedError
 
     @classmethod
-    def build_uut(cls, *args, **kwargs) -> Actuator:
+    def build_uut(cls, *args, **kwargs) -> AbsActuator:
         """
         Builds Unit Under Test (uut) - an instance of Actuator to be tested.
 


### PR DESCRIPTION
This pull request contains a lot of changes (including BREAKING changes) for the current structure and naming of Things-related components:

- all abstract implementations of Thing and derivative classes are now moved to `dpl.integrations` package;
- all abstract implementations of Thing and derivative classes now have the `Abs` prefix in their names;
- Thing class definition is remained unchanged (but there was an idea to rename it to the BaseThing);
- Thing base class now handles the saving of `con_instance` and `con_params` constructor params by itself;
- fixed a DTO construction for non-Actuator Things;
- UnsupportedCommandError and UnacceptableCommandArgumentsError exceptions are now defined in `things.capabilities.i_actuator` module;
- a lot of small PEP8 fixes (mostly for "line too long" errors).