### PR TITLE
Thing on_update events

### DIFF
--- a/dpl/integrations/abs_actuator.py
+++ b/dpl/integrations/abs_actuator.py
@@ -72,7 +72,7 @@ class AbsActuator(Thing, Actuator, HasState):
         :param new_value: new state value to be set
         :return: None
         """
-        self._last_updated = time.time()
+        self._apply_update()
         self._really_internal_state_value = new_value
 
     @property

--- a/dpl/things/update_callback.py
+++ b/dpl/things/update_callback.py
@@ -1,0 +1,34 @@
+from typing import Optional, Callable
+
+
+class UpdateCallback(object):
+    """
+    Implementations of UpdateCallback interface has an on_update property
+    that allows to define a single callback to be called on each update
+    of a Thing.
+
+    A callback to be registered must to accept a single parameter: a weak
+    reference to the event source (i.e. to the updated Thing)
+    """
+    @property
+    def on_update(self) -> Optional[Callable]:
+        """
+        Returns a callable that is currently registered to be called on each
+        update of this object
+
+        :return: a callable that is currently registered to be called on each
+                 update of this object; or None if a callable wasn't set yet
+        """
+        raise NotImplementedError()
+
+    @on_update.setter
+    def on_update(self, callback: Optional[Callable]) -> None:
+        """
+        Allows to set a callable to be called on each update of this object.
+        This callable must to accept a reference to the event source (i.e. to
+        this object)
+
+        :param callback: a new callback to be set or None to unset a callback
+        :return: None
+        """
+        raise NotImplementedError()


### PR DESCRIPTION
This pull request prepares infrastructure for tracking of updates of Things and their properties

- added a protected method called `_apply_update()` for notification of subscribers on Thing updates;
- added a new interface (abstract class) called UpdateCallback which allows to assign callbacks to be
  called on each update of an object (i.e. Thing);
- implemented UpdateCallback interface for a base Thing implementation;
- added `_apply_update()` calls for base Actuator implementation

Closes #12 