### PR TITLE
Observable repos

### DIFF
--- a/dpl/repo_impls/in_memory/thing_repository.py
+++ b/dpl/repo_impls/in_memory/thing_repository.py
@@ -1,8 +1,11 @@
-from typing import Optional, Sequence, MutableSequence
+import weakref
+from typing import Optional, Sequence, MutableSequence, MutableSet
 
+from dpl.utils.observer import Observer
 from dpl.model.domain_id import TDomainId
 from dpl.things.thing import Thing
 from .base_repository import BaseRepository
+from dpl.repos.observable_repository import EventType
 from dpl.repos.abs_thing_repository import AbsThingRepository
 
 
@@ -10,6 +13,121 @@ class ThingRepository(BaseRepository[Thing], AbsThingRepository):
     """
     An implementation of Things storage
     """
+    def __init__(self):
+        super().__init__()
+        self._observers = set()  # type: MutableSet[Observer]
+        self._weak_self = weakref.proxy(self)
+
+    def add(self, new_obj: Thing) -> None:
+        """
+        Add a new element to the storage
+
+        In addition to the base repository behaviour subscribes itself on any
+        updates to a Thing and notifies all Observers that a new object was
+        added to the Repository
+
+        :param new_obj: new object to be stored
+        :return: None
+        """
+        super().add(new_obj)
+        new_obj.on_update = self._thing_modified_callback
+        self._notify_added(thing=new_obj)
+
+    def delete(self, domain_id: TDomainId) -> None:
+        """
+        Removes an element with the specified ID from the storage
+
+        In addition to the base repository behaviour removes a subscription on
+        updates to a Thing and notifies all Observers that an object was
+        deleted from the Repository
+
+        :param domain_id: an ID of element to be removed
+        :return: None
+        """
+        thing = self.load(domain_id)
+        thing.on_update = None
+        super().delete(domain_id)
+        self._notify_deleted(thing_id=domain_id)
+
+    def _notify_added(self, thing: Thing) -> None:
+        """
+        Notifies all Observers that the specified Thing was added to this Repo
+
+        :param thing: an instance of a Thing that was added
+        :return: None
+        """
+        self._notify(
+            object_id=thing.domain_id,
+            event_type=EventType.added,
+            object_ref=weakref.proxy(thing)
+        )
+
+    def _notify_deleted(self, thing_id: TDomainId) -> None:
+        """
+        Notifies all Observers that a Thing with the specified ID was deleted
+        from a repository
+
+        :param thing_id: an identifier of a Thing that was deleted
+        :return: None
+        """
+        self._notify(
+            object_id=thing_id,
+            event_type=EventType.deleted,
+            object_ref=None
+        )
+
+    def _thing_modified_callback(self, thing: Thing) -> None:
+        """
+        A callback to be called by instances of a Thing when any of them will
+        be modified
+
+        :param thing: an instance of Thing that was modified
+        :return: None
+        """
+        self._notify(
+            object_id=thing.domain_id,
+            event_type=EventType.modified,
+            object_ref=weakref.proxy(thing)
+        )
+
+    def subscribe(self, observer: Observer) -> None:
+        """
+        Adds the specified Observer to the list of subscribers
+
+        :param observer: an instance of Observer to be added
+        :return: None
+        """
+        self._observers.add(observer)
+
+    def unsubscribe(self, observer: Observer) -> None:
+        """
+        Removes the specified  Observer from the list of subscribers
+
+        :param observer: an instance of Observer to be deleted
+        :return: None
+        """
+        self._observers.discard(observer)
+
+    def _notify(
+            self, object_id: TDomainId, event_type: EventType,
+            object_ref: Optional[Thing]
+    ):
+        """
+        Notifies all of the subscribers that an object was modified in,
+        added to or deleted from this Repository
+
+        :param object_id: an identifier of an altered object
+        :param event_type: enum value, specifies what happened to the object
+        :param object_ref: a reference to the altered object or None if it was
+               deleted
+        :return: None
+        """
+        for o in self._observers:
+            o.update(
+                source=self._weak_self,
+                event_type=event_type,
+                object_ref=object_ref
+            )
 
     def select_by_placement(self, placement_id: Optional[TDomainId]) -> Sequence[Thing]:
         """

--- a/dpl/repo_impls/in_memory/thing_repository.py
+++ b/dpl/repo_impls/in_memory/thing_repository.py
@@ -126,6 +126,7 @@ class ThingRepository(BaseRepository[Thing], AbsThingRepository):
             o.update(
                 source=self._weak_self,
                 event_type=event_type,
+                object_id=object_id,
                 object_ref=object_ref
             )
 

--- a/dpl/repo_impls/sql_alchemy/base_repository.py
+++ b/dpl/repo_impls/sql_alchemy/base_repository.py
@@ -18,7 +18,9 @@ class BaseRepository(AbsRepository[TEntity]):
     """
     A base implementation of SQLAlchemy-based repository
     """
-    def __init__(self, session_manager: DbSessionManager, stored_cls: Type[TEntity]):
+    def __init__(
+            self, session_manager: DbSessionManager, stored_cls: Type[TEntity]
+    ):
         """
         Constructor. Receives an instance of SessionManager
         to be used and saves a link to it to the internal

--- a/dpl/repo_impls/sql_alchemy/base_repository.py
+++ b/dpl/repo_impls/sql_alchemy/base_repository.py
@@ -145,6 +145,7 @@ class BaseRepository(AbsRepository[TEntity], ObservableRepository[TEntity]):
             o.update(
                 source=self._weak_self,
                 event_type=event_type,
+                object_id=object_id,
                 object_ref=object_ref
             )
 

--- a/dpl/repo_impls/sql_alchemy/base_repository.py
+++ b/dpl/repo_impls/sql_alchemy/base_repository.py
@@ -218,6 +218,5 @@ class BaseRepository(AbsRepository[TEntity], ObservableRepository[TEntity]):
         :param domain_id: an ID of element to be removed
         :return: None
         """
-        query = self._session.query(self._stored_cls)
-        on_delete = query.filter(self._stored_cls._domain_id == domain_id)
-        on_delete.delete()
+        on_delete = self.load(domain_id)
+        self._session.delete(on_delete)

--- a/dpl/repos/abs_thing_repository.py
+++ b/dpl/repos/abs_thing_repository.py
@@ -1,10 +1,11 @@
 from typing import Optional
 
 from .abs_repository import AbsRepository, TDomainId
+from .observable_repository import ObservableRepository
 from dpl.things import Thing
 
 
-class AbsThingRepository(AbsRepository[Thing]):
+class AbsThingRepository(AbsRepository[Thing], ObservableRepository[Thing]):
     """
     Pure abstract base implementation of Repository
     containing Things.

--- a/dpl/repos/observable_repository.py
+++ b/dpl/repos/observable_repository.py
@@ -1,0 +1,38 @@
+from enum import Enum
+from typing import TypeVar, Generic, Optional
+
+from dpl.utils.observable import Observable
+from dpl.model.domain_id import TDomainId
+
+
+T = TypeVar('T')
+
+
+class EventType(Enum):
+    added = 0
+    modified = 1
+    deleted = 2
+
+
+class ObservableRepository(Observable, Generic[T]):
+    """
+    ObservableRepository is a declaration of an interface to be implemented
+    by Observable Repositories. Is a sample of Observable pattern; notifies all
+    subscribers (Observers) that any of the objects stored in the repository
+    was added, modified or deleted
+    """
+    def _notify(
+            self, object_id: TDomainId, event_type: EventType,
+            object_ref: Optional[T]
+    ) -> None:
+        """
+        Notifies all of the subscribers that an object was modified in,
+        added to or deleted from this Repository
+
+        :param object_id: an identifier of an altered object
+        :param event_type: enum value, specifies what happened to the object
+        :param object_ref: a reference to the altered object or None if it was
+               deleted
+        :return: None
+        """
+        raise NotImplementedError()

--- a/dpl/utils/observable.py
+++ b/dpl/utils/observable.py
@@ -25,15 +25,3 @@ class Observable(object):
         :return: None
         """
         raise NotImplementedError()
-
-    def _notify(self, *args, **kwargs) -> None:
-        """
-        A method to be called if a new event was emitted by this Observer
-
-        :param args: optional, additional information about an event to be
-               passed to Observers
-        :param kwargs: optional, additional information about an event to be
-               passed to Observers
-        :return: None
-        """
-        raise NotImplementedError()

--- a/dpl/utils/observable.py
+++ b/dpl/utils/observable.py
@@ -1,0 +1,39 @@
+from .observer import Observer
+
+
+class Observable(object):
+    """
+    Observable is an abstract class which declares the interface to be
+    implemented by Observable pattern implementations. It specifies methods
+    for subscription and cancelling subscriptions of Observers. And a
+    protected method ``notify`` to be used for notification of Observers
+    """
+    def subscribe(self, observer: Observer) -> None:
+        """
+        Adds the specified Observer to the list of subscribers
+
+        :param observer: an instance of Observer to be added
+        :return: None
+        """
+        raise NotImplementedError()
+
+    def unsubscribe(self, observer: Observer) -> None:
+        """
+        Removes the specified  Observer from the list of subscribers
+
+        :param observer: an instance of Observer to be deleted
+        :return: None
+        """
+        raise NotImplementedError()
+
+    def _notify(self, *args, **kwargs) -> None:
+        """
+        A method to be called if a new event was emitted by this Observer
+
+        :param args: optional, additional information about an event to be
+               passed to Observers
+        :param kwargs: optional, additional information about an event to be
+               passed to Observers
+        :return: None
+        """
+        raise NotImplementedError()

--- a/dpl/utils/observer.py
+++ b/dpl/utils/observer.py
@@ -1,0 +1,23 @@
+from typing import TypeVar, Generic
+
+T = TypeVar('T')
+
+
+class Observer(Generic[T]):
+    """
+    Observer is an abstract class which declares the interface to be
+    implemented by Observer pattern implementations. It specifies a method
+    for handling of events emitted by Observers - update
+    """
+    def update(self, source: T, *args, **kwargs) -> None:
+        """
+        A method to be called by Observables on any new events emitted
+
+        :param source: mandatory, a weak reference to the event source
+        :param args: optional positional arguments with additional information
+               about emitted event
+        :param kwargs: optional keyword arguments with additional information
+               about emitted event
+        :return: None
+        """
+        raise NotImplementedError()

--- a/tests/repos/test_thing_repo.py
+++ b/tests/repos/test_thing_repo.py
@@ -1,0 +1,95 @@
+"""
+This module contains unit tests for an in-memory ThingRepository implementation
+"""
+
+import unittest
+import uuid
+import weakref
+from unittest.mock import Mock
+
+from dpl.connections import Connection
+from dpl.things.thing import Thing
+from dpl.repo_impls.in_memory.thing_repository import ThingRepository
+from dpl.utils.observer import Observer
+from dpl.repos.observable_repository import EventType
+
+
+class TestThingRepository(unittest.TestCase):
+    def setUp(self):
+        self.con_mock = Mock(spec_set=Connection)  # type: Connection
+        self.thing_id = uuid.uuid4()
+        self.thing_ins = Thing(
+            domain_id=self.thing_id,
+            con_instance=self.con_mock,
+            con_params={}
+        )
+
+        self.filled_thing_repo = ThingRepository()
+        self.filled_thing_repo.add(self.thing_ins)
+        self.observer = Mock(spec_set=Observer)  # type: Observer
+        self.observer_callback = self.observer.update  # type: Mock
+        self.filled_thing_repo.subscribe(self.observer)
+
+    def test_init(self):
+        thing_repo = ThingRepository()
+
+        self.assertEqual(
+            0, thing_repo.count()
+        )
+
+        self.assertFalse(  # assert that an empty container was returned
+            thing_repo.load_all()
+        )
+
+    def test_add_element(self):
+        thing_repo = ThingRepository()
+
+        thing_repo.subscribe(self.observer)
+        self.observer_callback.assert_not_called()
+
+        thing_repo.add(self.thing_ins)
+
+        self.assertEqual(
+            1, thing_repo.count()
+        )
+        self.assertIs(
+            thing_repo.load(self.thing_id), self.thing_ins
+        )
+
+        all_things = thing_repo.load_all()
+
+        self.assertEqual(
+            thing_repo.count(),
+            len(all_things)
+        )
+        self.assertIn(
+            self.thing_ins, all_things
+        )
+
+        self.observer_callback.assert_called_once_with(
+            source=weakref.proxy(thing_repo),
+            event_type=EventType.added,
+            object_ref=weakref.proxy(self.thing_ins)
+        )
+
+    def test_delete_element(self):
+        assert self.filled_thing_repo.count() == 1
+        assert self.thing_ins in self.filled_thing_repo.load_all()
+
+        self.filled_thing_repo.delete(domain_id=self.thing_id)
+
+        self.assertEqual(
+            0, self.filled_thing_repo.count()
+        )
+        self.assertFalse(
+            self.filled_thing_repo.load_all()
+        )
+        self.assertIsNone(
+            self.filled_thing_repo.load(self.thing_id)
+        )
+
+        self.observer_callback.assert_called_once_with(
+            source=weakref.proxy(self.filled_thing_repo),
+            event_type=EventType.deleted,
+            object_ref=None
+        )

--- a/tests/repos/test_thing_repo.py
+++ b/tests/repos/test_thing_repo.py
@@ -95,3 +95,15 @@ class TestThingRepository(unittest.TestCase):
             object_id=self.thing_id,
             object_ref=None
         )
+
+    def test_modify_element(self):
+        assert self.thing_ins in self.filled_thing_repo.load_all()
+
+        self.thing_ins._apply_update()
+
+        self.observer_callback.assert_called_once_with(
+            source=weakref.proxy(self.filled_thing_repo),
+            event_type=EventType.modified,
+            object_id=self.thing_id,
+            object_ref=self.thing_ins
+        )

--- a/tests/repos/test_thing_repo.py
+++ b/tests/repos/test_thing_repo.py
@@ -69,6 +69,7 @@ class TestThingRepository(unittest.TestCase):
         self.observer_callback.assert_called_once_with(
             source=weakref.proxy(thing_repo),
             event_type=EventType.added,
+            object_id=self.thing_id,
             object_ref=weakref.proxy(self.thing_ins)
         )
 
@@ -91,5 +92,6 @@ class TestThingRepository(unittest.TestCase):
         self.observer_callback.assert_called_once_with(
             source=weakref.proxy(self.filled_thing_repo),
             event_type=EventType.deleted,
+            object_id=self.thing_id,
             object_ref=None
         )


### PR DESCRIPTION
This pull request proposes a conception of the ObservableRepository - a Repository which implements an Observable interface.

- declared two new utility classes: Observable and Observer;
- declared the ObservableRepository interface;
- implemented ObservableRepository interface for all SQLAlchemy-based repositories;
- implemented ObservableRepository interface for an in-memory implementation of ThingRepository.

Related to the #11 